### PR TITLE
Run tests on all platforms

### DIFF
--- a/tests/AsyncBridge.Tests/AsyncBridge.Tests.csproj
+++ b/tests/AsyncBridge.Tests/AsyncBridge.Tests.csproj
@@ -41,6 +41,7 @@
     <Compile Include="DelayTest.cs" />
     <Compile Include="SyncContextTests.cs" />
     <Compile Include="Test.cs" />
+    <Compile Include="TestUtils.cs" />
     <Compile Include="WhenAllTests.cs" />
     <Compile Include="WhenAnyTests.cs" />
   </ItemGroup>

--- a/tests/AsyncBridge.Tests/DelayTest.cs
+++ b/tests/AsyncBridge.Tests/DelayTest.cs
@@ -20,34 +20,46 @@ namespace AsyncBridge.Tests
     public class DelayTest
     {
         [TestMethod]
-        public async Task CheckItDoesReturn()
+        public void CheckItDoesReturn()
         {
-            await TaskEx.Delay(1);
+            TestUtils.RunAsync(async () =>
+            {
+                await TaskEx.Delay(1);
+            });
         }
 
         [TestMethod]
-        public async Task TimeSpanVersion()
+        public void TimeSpanVersion()
         {
-            await TaskEx.Delay(TimeSpan.FromMilliseconds(1));
+            TestUtils.RunAsync(async () =>
+            {
+                await TaskEx.Delay(TimeSpan.FromMilliseconds(1));
+            });
         }
 
         [TestMethod, ExpectedException(typeof (TaskCanceledException))]
-        public async Task CancelImmediately()
+        public void CancelImmediately()
         {
-            var cancellationToken = new CancellationToken(true);
-            await TaskEx.Delay(1, cancellationToken);
+            TestUtils.RunAsync(async () =>
+            {
+                var cancellationToken = new CancellationToken(true);
+                await TaskEx.Delay(1, cancellationToken);
+            });
         }
 
         [TestMethod]
-        public async Task ResiliantToGc()
+        public void ResiliantToGc()
         {
-            var keepGcing = true;
-            // ReSharper disable AccessToModifiedClosure
-            var gcAllTheTime = new Thread(() => { while (keepGcing) GC.Collect(); });
-            // ReSharper restore AccessToModifiedClosure
-            gcAllTheTime.Start();
-            await TaskEx.Delay(500);
-            keepGcing = false;
+            TestUtils.RunAsync(async () =>
+            {
+                var keepGcing = true;
+                // ReSharper disable AccessToModifiedClosure
+                var gcAllTheTime = new Thread(() => { while (keepGcing) GC.Collect(); });
+                // ReSharper restore AccessToModifiedClosure
+                gcAllTheTime.Start();
+                await TaskEx.Delay(500);
+                keepGcing = false;
+            });
         }
     }
 }

--- a/tests/AsyncBridge.Tests/SyncContextTests.cs
+++ b/tests/AsyncBridge.Tests/SyncContextTests.cs
@@ -76,140 +76,139 @@ namespace AsyncBridge.Tests
         }
 
         [TestMethod]
-        public async Task YieldSyncContext()
+        public void YieldSyncContext()
         {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            await TaskEx.Yield();
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-        }
-
-        [TestMethod]
-        public async Task FromResultSyncContext()
-        {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            int r = await TaskEx.FromResult(4);
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-            Assert.AreEqual(4, r);
-        }
-
-
-        [TestMethod]
-        public void DelaySyncContext_wrapped()
-        {
-            var t = DelaySyncContext();
-            t.Wait();
-        }
-
-        [TestMethod, Ignore]
-        public void NotCapturedReturningTaskSyncContext_wrapped()
-        {
-            var t = NotCapturedReturningTaskSyncContext();
-            t.Wait();
-        }
-
-        [TestMethod, Ignore]
-        public void NotCapturedSimpleTaskSyncContext_wrapped()
-        {
-            var t = NotCapturedSimpleTaskSyncContext();
-            t.Wait();
-        }
-        [TestMethod]
-        public void CapturedSimpleTaskSyncContext_wrapped()
-        {
-            var t = CapturedSimpleTaskSyncContext();
-            t.Wait();
-        }
-
-
-        [TestMethod]
-        public async Task DelaySyncContext()
-        {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            await TaskEx.Delay(10);
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-        }
-
-        [TestMethod]
-        public async Task SimpleTaskSyncContext()
-        {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            await WaitABit();
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-        }
-
-        [TestMethod]
-        public async Task ReturningTaskSyncContext()
-        {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            int r = await WaitAThing();
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-            Assert.AreEqual(6, r);
-        }
-
-        [TestMethod, Ignore]
-        public async Task NotCapturedSimpleTaskSyncContext()
-        {
-            Write.Line("START");
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            await TaskEx.Run(async () =>
+            TestUtils.RunAsync(async () =>
             {
-                Write.Line("A");
-                SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
-                Write.Line("B");
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                await TaskEx.Yield();
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+            });
+        }
+
+        [TestMethod]
+        public void FromResultSyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                int r = await TaskEx.FromResult(4);
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+                Assert.AreEqual(4, r);
+            });
+        }
+
+        [TestMethod]
+        public void DelaySyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                await TaskEx.Delay(10);
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+            });
+        }
+
+        [TestMethod]
+        public void SimpleTaskSyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
                 await WaitABit();
-                Write.Line("C");
-            }).ConfigureAwait(false);
-            Write.Line("END");
-            Assert.AreNotSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-        }
-        [TestMethod]
-        public async Task CapturedSimpleTaskSyncContext()
-        {
-            Write.Line("START");
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            await TaskEx.Run(async () =>
-            {
-                Write.Line("A");
-                SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
-                Write.Line("B");
-                await WaitABit();
-                Write.Line("C");
-            }).ConfigureAwait(true);
-            Write.Line("END");
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+            });
         }
 
         [TestMethod]
-        public async Task CapturedReturningTaskSyncContext()
+        public void ReturningTaskSyncContext()
         {
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            int r = await TaskEx.Run(async () =>
+            TestUtils.RunAsync(async () =>
             {
-                SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
-                return await WaitAThing();
-            }).ConfigureAwait(true);
-
-            Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-            Assert.AreEqual(6, r);
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                int r = await WaitAThing();
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+                Assert.AreEqual(6, r);
+            });
         }
 
         [TestMethod, Ignore]
-        public async Task NotCapturedReturningTaskSyncContext()
+        public void NotCapturedSimpleTaskSyncContext()
         {
-            Write.Line("START");
-            SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
-            int r = await TaskEx.Run(async () =>
+            TestUtils.RunAsync(async () =>
             {
-                Write.Line("A");
-                SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
-                Write.Line("B");
-                var result = await WaitAThing();
-                Write.Line("C");
-                return result;
-            }).ConfigureAwait(false);
-            Write.Line("END");
-            Assert.AreNotSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
-            Assert.AreEqual(6, r);
+                Write.Line("START");
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                await TaskEx.Run(async () =>
+                {
+                    Write.Line("A");
+                    SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
+                    Write.Line("B");
+                    await WaitABit();
+                    Write.Line("C");
+                }).ConfigureAwait(false);
+                Write.Line("END");
+                Assert.AreNotSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+            });
+        }
+
+        [TestMethod]
+        public void CapturedSimpleTaskSyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                Write.Line("START");
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                await TaskEx.Run(async () =>
+                {
+                    Write.Line("A");
+                    SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
+                    Write.Line("B");
+                    await WaitABit();
+                    Write.Line("C");
+                }).ConfigureAwait(true);
+                Write.Line("END");
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+            });
+        }
+
+        [TestMethod]
+        public void CapturedReturningTaskSyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                int r = await TaskEx.Run(async () =>
+                {
+                    SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
+                    return await WaitAThing();
+                }).ConfigureAwait(true);
+
+                Assert.AreSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+                Assert.AreEqual(6, r);
+            });
+        }
+
+        [TestMethod, Ignore]
+        public void NotCapturedReturningTaskSyncContext()
+        {
+            TestUtils.RunAsync(async () =>
+            {
+                Write.Line("START");
+                SynchronizationContext.SetSynchronizationContext(MagicSynchronizationContext.Instance);
+                int r = await TaskEx.Run(async () =>
+                {
+                    Write.Line("A");
+                    SynchronizationContext.SetSynchronizationContext(WickedSynchronizationContext.Instance);
+                    Write.Line("B");
+                    var result = await WaitAThing();
+                    Write.Line("C");
+                    return result;
+                }).ConfigureAwait(false);
+                Write.Line("END");
+                Assert.AreNotSame(SynchronizationContext.Current, MagicSynchronizationContext.Instance);
+                Assert.AreEqual(6, r);
+            });
         }
 
         /// <summary>

--- a/tests/AsyncBridge.Tests/Test.cs
+++ b/tests/AsyncBridge.Tests/Test.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#if !NET35 // This file verifies that async tests work, but MSTest cannot discover async tests on net35
+
+using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 #if NET45
@@ -9,8 +11,6 @@ using TaskEx = System.Threading.Tasks.Task;
 
 #if NET45
 namespace ReferenceAsync.Tests
-#elif NET35
-namespace AsyncBridge.Net35.Tests
 #elif ATP
 namespace AsyncTargetingPack.Tests
 #else
@@ -40,3 +40,5 @@ namespace AsyncBridge.Tests
         }
     }
 }
+
+#endif

--- a/tests/AsyncBridge.Tests/TestUtils.cs
+++ b/tests/AsyncBridge.Tests/TestUtils.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Threading.Tasks;
+
+#if NET45
+namespace ReferenceAsync.Tests
+#elif NET35
+namespace AsyncBridge.Net35.Tests
+#elif ATP
+namespace AsyncTargetingPack.Tests
+#else
+namespace AsyncBridge.Tests
+#endif
+{
+    internal static class TestUtils
+    {
+        public static void RunAsync(Func<Task> asyncTestMethod)
+        {
+            if (asyncTestMethod == null) throw new ArgumentNullException(nameof(asyncTestMethod));
+            asyncTestMethod.Invoke().GetAwaiter().GetResult();
+        }
+    }
+}

--- a/tests/AsyncBridge.Tests/WhenAllTests.cs
+++ b/tests/AsyncBridge.Tests/WhenAllTests.cs
@@ -19,20 +19,23 @@ namespace AsyncBridge.Tests
     public class WhenAllTests
     {
         [TestMethod]
-        public async Task GenericIEnumerableWithSomeContents()
+        public void GenericIEnumerableWithSomeContents()
         {
-            var taskCompletionSources = new []
-                                        {
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>()
-                                        };
-            var whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task));
-            taskCompletionSources[0].SetResult(1);
-            taskCompletionSources[1].SetResult(2);
-            taskCompletionSources[2].SetResult(3);
-            var results = await whenAllTask;
-            CollectionAssert.AreEquivalent(new[] {1, 2, 3}, results.ToList());
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                var whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task));
+                taskCompletionSources[0].SetResult(1);
+                taskCompletionSources[1].SetResult(2);
+                taskCompletionSources[2].SetResult(3);
+                var results = await whenAllTask;
+                CollectionAssert.AreEquivalent(new[] {1, 2, 3}, results.ToList());
+            });
         }
 
         [TestMethod]
@@ -49,33 +52,39 @@ namespace AsyncBridge.Tests
         }
 
         [TestMethod]
-        public async Task NonGenericVersion()
+        public void NonGenericVersion()
         {
-            var taskCompletionSources = new []
-                                        {
-                                            new TaskCompletionSource<int>(), 
-                                            new TaskCompletionSource<int>()
-                                        };
-            var whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task).Cast<Task>());
-            taskCompletionSources[0].SetResult(1);
-            Assert.IsFalse(whenAllTask.IsCompleted);
-            taskCompletionSources[1].SetResult(1);
-            await whenAllTask;
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                var whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task).Cast<Task>());
+                taskCompletionSources[0].SetResult(1);
+                Assert.IsFalse(whenAllTask.IsCompleted);
+                taskCompletionSources[1].SetResult(1);
+                await whenAllTask;
+            });
         }
 
         [TestMethod]
-        public async Task ArrayVersion()
+        public void ArrayVersion()
         {
-            var taskCompletionSources = new[]
-                                        {
-                                            new TaskCompletionSource<int>(), 
-                                            new TaskCompletionSource<int>()
-                                        };
-            Task whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task).ToArray());
-            taskCompletionSources[0].SetResult(1);
-            Assert.IsFalse(whenAllTask.IsCompleted);
-            taskCompletionSources[1].SetResult(1);
-            await whenAllTask;
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                Task whenAllTask = TaskEx.WhenAll(taskCompletionSources.Select(tcs => tcs.Task).ToArray());
+                taskCompletionSources[0].SetResult(1);
+                Assert.IsFalse(whenAllTask.IsCompleted);
+                taskCompletionSources[1].SetResult(1);
+                await whenAllTask;
+            });
         }
     }
 }

--- a/tests/AsyncBridge.Tests/WhenAnyTests.cs
+++ b/tests/AsyncBridge.Tests/WhenAnyTests.cs
@@ -19,46 +19,55 @@ namespace AsyncBridge.Tests
     public class WhenAnyTests
     {
         [TestMethod]
-        public async Task GenericArrayWithSomeContents()
+        public void GenericArrayWithSomeContents()
         {
-            var taskCompletionSources = new []
-                                        {
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>()
-                                        };
-            var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task).ToArray());
-            taskCompletionSources[1].SetResult(2);
-            var result = await whenAnyTask;
-            Assert.AreEqual(2, await result);
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task).ToArray());
+                taskCompletionSources[1].SetResult(2);
+                var result = await whenAnyTask;
+                Assert.AreEqual(2, await result);
+            });
         }
 
         [TestMethod]
-        public async Task GenericIEnumerableWithSomeContents()
+        public void GenericIEnumerableWithSomeContents()
         {
-            var taskCompletionSources = new []
-                                        {
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>()
-                                        };
-            var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task));
-            taskCompletionSources[1].SetResult(2);
-            var result = await whenAnyTask;
-            Assert.AreEqual(2, await result);
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task));
+                taskCompletionSources[1].SetResult(2);
+                var result = await whenAnyTask;
+                Assert.AreEqual(2, await result);
+            });
         }
 
         [TestMethod]
-        public async Task EnumerableWithSomeContents()
+        public void EnumerableWithSomeContents()
         {
-            var taskCompletionSources = new []
-                                        {
-                                            new TaskCompletionSource<int>(),
-                                            new TaskCompletionSource<int>()
-                                        };
-            var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task).Cast<Task>());
-            Assert.IsFalse(whenAnyTask.IsCompleted);
-            taskCompletionSources[1].SetResult(2);
-            await await whenAnyTask;
+            TestUtils.RunAsync(async () =>
+            {
+                var taskCompletionSources = new[]
+                {
+                    new TaskCompletionSource<int>(),
+                    new TaskCompletionSource<int>()
+                };
+                var whenAnyTask = TaskEx.WhenAny(taskCompletionSources.Select(tcs => tcs.Task).Cast<Task>());
+                Assert.IsFalse(whenAnyTask.IsCompleted);
+                taskCompletionSources[1].SetResult(2);
+                await await whenAnyTask;
+            });
         }
     }
 }


### PR DESCRIPTION
Fixes #8 

No semantics have changed as a result of moving the `async Task` test methods to `async Task` lambdas.