### PR TITLE
Add extensions for missing methods on Task and CancellationTokenSource, and fixes for Partial Trust

### DIFF
--- a/src/AsyncBridge/AsyncCompatLibExtensions.cs
+++ b/src/AsyncBridge/AsyncCompatLibExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable CheckNamespace
@@ -84,6 +85,171 @@ public static class AsyncCompatLibExtensions
             throw new ArgumentNullException("task");
 
         return new ConfiguredTaskAwaitable(task, continueOnCapturedContext);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state));
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state));
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, TaskContinuationOptions.None, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, TaskContinuationOptions.None, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, TaskContinuationOptions.None, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, TaskContinuationOptions.None, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Causes a cancellation token source to cancel after a specified time
+    /// </summary>
+    /// <param name="cancelSource">The cancellation token source to cancel</param>
+    /// <param name="delay">The time to wait before cancellation</param>
+    public static void CancelAfter(this CancellationTokenSource cancelSource, TimeSpan delay)
+    {
+        Timer MyTimer = null;
+
+        MyTimer = new Timer(state =>
+        {
+            MyTimer.Dispose();
+
+            try
+            {
+                if (cancelSource.Token.CanBeCanceled)
+                    cancelSource.Cancel();
+            }
+            catch (ObjectDisposedException) // If the cancellation token has been disposed of, ignore the exception
+            {
+            }
+        }, null, Timeout.Infinite, Timeout.Infinite);
+
+        MyTimer.Change(delay, new TimeSpan(0, 0, 0, 0, -1));
     }
 }
 // ReSharper restore CheckNamespace

--- a/src/AsyncBridge/Properties/SpecificAssemblyInfo.cs
+++ b/src/AsyncBridge/Properties/SpecificAssemblyInfo.cs
@@ -1,0 +1,6 @@
+﻿using System.Security;
+
+#if !NET35 && !PORTABLE
+[assembly: AllowPartiallyTrustedCallers]
+[assembly: SecurityRules(SecurityRuleSet.Level2)]
+#endif

--- a/src/AsyncBridge/Runtime.CompilerServices/AsyncVoidMethodBuilder.cs
+++ b/src/AsyncBridge/Runtime.CompilerServices/AsyncVoidMethodBuilder.cs
@@ -79,6 +79,7 @@ namespace System.Runtime.CompilerServices
         /// <summary>
         /// Registers with UnobservedTaskException to suppress exception crashing.
         /// </summary>
+        [SecuritySafeCritical]
         internal static void PreventUnobservedTaskExceptions()
         {
             if (Interlocked.CompareExchange(ref s_preventUnobservedTaskExceptionsInvoked, 1, 0) != 0)

--- a/src/pubapi/AsyncBridge.net35-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net35-client.pubapi.cs
@@ -3,9 +3,31 @@
 
 public static class AsyncCompatLibExtensions
 {
+    public static void CancelAfter(this System.Threading.CancellationTokenSource cancelSource, System.TimeSpan delay);
+
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait<TResult>(this System.Threading.Tasks.Task<TResult> task, bool continueOnCapturedContext);
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/src/pubapi/AsyncBridge.net40-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net40-client.pubapi.cs
@@ -3,9 +3,31 @@
 
 public static class AsyncCompatLibExtensions
 {
+    public static void CancelAfter(this System.Threading.CancellationTokenSource cancelSource, System.TimeSpan delay);
+
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait<TResult>(this System.Threading.Tasks.Task<TResult> task, bool continueOnCapturedContext);
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
+++ b/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
@@ -3,9 +3,31 @@
 
 public static class AsyncCompatLibExtensions
 {
+    public static void CancelAfter(this System.Threading.CancellationTokenSource cancelSource, System.TimeSpan delay);
+
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable<TResult> ConfigureAwait<TResult>(this System.Threading.Tasks.Task<TResult> task, bool continueOnCapturedContext);
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/tests/AsyncBridge.Tests/AsyncBridge.Tests.csproj
+++ b/tests/AsyncBridge.Tests/AsyncBridge.Tests.csproj
@@ -9,6 +9,10 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFrameworkVersion Condition="'$(TargetFramework)' == 'net40'">v4.0</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition="'$(TargetFramework)' == 'net35'">v3.5</TargetFrameworkVersion>

--- a/tests/AsyncTargetingPack.Tests/AsyncTargetingPack.Tests.csproj
+++ b/tests/AsyncTargetingPack.Tests/AsyncTargetingPack.Tests.csproj
@@ -14,6 +14,10 @@
     <Compile Include="..\AsyncBridge.Tests\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
   <PropertyGroup>
     <AssemblySearchPaths>
       $(AssemblySearchPaths);

--- a/tests/ReferenceAsync.Net45/ReferenceAsync.Net45.csproj
+++ b/tests/ReferenceAsync.Net45/ReferenceAsync.Net45.csproj
@@ -12,6 +12,10 @@
     <Compile Include="..\AsyncBridge.Tests\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+
   <PropertyGroup>
     <AssemblySearchPaths>
       $(AssemblySearchPaths);


### PR DESCRIPTION
Adds missing Task ContinueWith overloads
Adds CancellationTokenSource.CancelAfter
Adds support for running in a Partial Trust environment

Seems Visual Studio added some elements to the project files as well. They can probably be excluded.

CancelAfter is a little ugly, since there's no way to tell if/when the CancellationTokenSource is disposed of. This means the timer will linger until it triggers, and then cleans itself up. Not sure how it can be improved.