### PR TITLE
ContinueWith overloads

### DIFF
--- a/src/AsyncBridge/AsyncCompatLibExtensions.cs
+++ b/src/AsyncBridge/AsyncCompatLibExtensions.cs
@@ -150,7 +150,7 @@ public static class AsyncCompatLibExtensions
     /// <returns>A task representing the continuation status</returns>
     public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
     {
-        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, token, taskOptions, scheduler);
     }
 
     /// <summary>

--- a/src/AsyncBridge/AsyncCompatLibExtensions.cs
+++ b/src/AsyncBridge/AsyncCompatLibExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 
 // ReSharper disable CheckNamespace
@@ -84,6 +85,343 @@ public static class AsyncCompatLibExtensions
             throw new ArgumentNullException("task");
 
         return new ConfiguredTaskAwaitable(task, continueOnCapturedContext);
+    }
+  
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state)
+    {
+        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, token);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, TaskContinuationOptions taskOptions)
+    {
+        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith((innerTask) => action(innerTask, state), token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state)
+    {
+        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, token);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, TaskContinuationOptions taskOptions)
+    {
+        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">A set of task continuation options to apply</param>
+    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state)
+    {
+        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, token);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, TaskContinuationOptions taskOptions)
+    {
+        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state)
+    {
+        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token)
+    {
+        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, token);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, TaskContinuationOptions taskOptions)
+    {
+        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+    }
+
+    /// <summary>
+    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// </summary>
+    /// <param name="task">The target Task</param>
+    /// <param name="action">The continuation method to execute</param>
+    /// <param name="state">A state object to pass to the continuation</param>
+    /// <param name="token">A cancellation token to abort the continuation</param>
+    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
+    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
+    /// <returns>A task representing the continuation status</returns>
+    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    {
+        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+    }
+
+    private sealed class ContinueWithState
+    {
+        private readonly Action<Task, object> _Callback;
+        private readonly object _State;
+
+        internal ContinueWithState(Action<Task, object> callback, object state)
+        {
+            _Callback = callback;
+            _State = state;
+        }
+
+        internal void ContinueWith(Task task)
+        {
+            _Callback(task, _State);
+        }
+    }
+
+    private sealed class ContinueWithInState<TIn>
+    {
+        private readonly Action<Task<TIn>, object> _Callback;
+        private readonly object _State;
+
+        internal ContinueWithInState(Action<Task<TIn>, object> callback, object state)
+        {
+            _Callback = callback;
+            _State = state;
+        }
+
+        internal void ContinueWith(Task<TIn> task)
+        {
+            _Callback(task, _State);
+        }
+    }
+
+    private sealed class ContinueWithOutState<TOut>
+    {
+        private readonly Func<Task, object, TOut> _Callback;
+        private readonly object _State;
+
+        internal ContinueWithOutState(Func<Task, object, TOut> callback, object state)
+        {
+            _Callback = callback;
+            _State = state;
+        }
+
+        internal TOut ContinueWith(Task task)
+        {
+            return _Callback(task, _State);
+        }
+    }
+
+    private sealed class ContinueWithInOutState<TIn, TOut>
+    {
+        private readonly Func<Task<TIn>, object, TOut> _Callback;
+        private readonly object _State;
+
+        internal ContinueWithInOutState(Func<Task<TIn>, object, TOut> callback, object state)
+        {
+            _Callback = callback;
+            _State = state;
+        }
+
+        internal TOut ContinueWith(Task<TIn> task)
+        {
+            return _Callback(task, _State);
+        }
     }
 }
 // ReSharper restore CheckNamespace

--- a/src/AsyncBridge/AsyncCompatLibExtensions.cs
+++ b/src/AsyncBridge/AsyncCompatLibExtensions.cs
@@ -33,7 +33,7 @@ public static class AsyncCompatLibExtensions
     {
         if (task == null)
             throw new ArgumentNullException("task");
-        
+
         return new TaskAwaiter(task);
     }
 
@@ -49,7 +49,7 @@ public static class AsyncCompatLibExtensions
     {
         if (task == null)
             throw new ArgumentNullException("task");
-        
+
         return new TaskAwaiter<TResult>(task);
     }
 
@@ -86,341 +86,773 @@ public static class AsyncCompatLibExtensions
 
         return new ConfiguredTaskAwaitable(task, continueOnCapturedContext);
     }
-  
+
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith(this Task task, Action<Task, object> action, object state)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task as and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    public static Task ContinueWith(this Task task, Action<Task, object> continuationAction, object state)
     {
-        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith);
+        return task.ContinueWith(new ContinueWithState(continuationAction, state).ContinueWith);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="cancellationToken"> The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task ContinueWith(this Task task, Action<Task, object> continuationAction, object state, CancellationToken cancellationToken)
     {
-        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, token);
+        return task.ContinueWith(new ContinueWithState(continuationAction, state).ContinueWith, cancellationToken);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="taskOptions">A set of task continuation options to apply</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, TaskContinuationOptions taskOptions)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed. If the continuation criteria specified through the <paramref
+    /// name="continuationOptions"/> parameter are not met, the continuation task will be canceled
+    /// instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    public static Task ContinueWith(this Task task, Action<Task, object> continuationAction, object state, TaskContinuationOptions continuationOptions)
     {
-        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+        return task.ContinueWith(new ContinueWithState(continuationAction, state).ContinueWith, CancellationToken.None, continuationOptions, TaskScheduler.Current);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, TaskScheduler scheduler)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task"/> completes.  When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    public static Task ContinueWith(this Task task, Action<Task, object> continuationAction, object state, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+        return task.ContinueWith(new ContinueWithState(continuationAction, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <param name="taskOptions">A set of task continuation options to apply</param>
-    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith(this Task task, Action<Task, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its
+    /// execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed. If the criteria specified through the <paramref name="continuationOptions"/> parameter
+    /// are not met, the continuation task will be canceled instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task ContinueWith(this Task task, Action<Task, object> continuationAction, object state, CancellationToken cancellationToken, TaskContinuationOptions continuationOptions, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithState(action, state).ContinueWith, token, taskOptions, scheduler);
+        return task.ContinueWith(new ContinueWithState(continuationAction, state).ContinueWith, cancellationToken, continuationOptions, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
-    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <typeparam name="TResult">The type of result from the target task</typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    public static Task ContinueWith<TResult>(this Task<TResult> task, Action<Task<TResult>, object> continuationAction, object state)
     {
-        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith);
+        return task.ContinueWith(new ContinueWithInState<TResult>(continuationAction, state).ContinueWith);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
-    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <typeparam name="TResult">The type of result from the target task</typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task ContinueWith<TResult>(this Task<TResult> task, Action<Task<TResult>, object> continuationAction, object state, CancellationToken cancellationToken)
     {
-        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, token);
+        return task.ContinueWith(new ContinueWithInState<TResult>(continuationAction, state).ContinueWith, cancellationToken);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
-    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <typeparam name="TResult">The type of result from the target task</typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="taskOptions">A set of task continuation options to apply</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, TaskContinuationOptions taskOptions)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed. If the continuation criteria specified through the <paramref
+    /// name="continuationOptions"/> parameter are not met, the continuation task will be canceled
+    /// instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    public static Task ContinueWith<TResult>(this Task<TResult> task, Action<Task<TResult>, object> continuationAction, object state, TaskContinuationOptions continuationOptions)
     {
-        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+        return task.ContinueWith(new ContinueWithInState<TResult>(continuationAction, state).ContinueWith, CancellationToken.None, continuationOptions, TaskScheduler.Current);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
-    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <typeparam name="TResult">The type of result from the target task</typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, TaskScheduler scheduler)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    public static Task ContinueWith<TResult>(this Task<TResult> task, Action<Task<TResult>, object> continuationAction, object state, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+        return task.ContinueWith(new ContinueWithInState<TResult>(continuationAction, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
-    /// <typeparam name="TInResult">The type of result from the target task</typeparam>
+    /// <typeparam name="TResult">The type of result from the target task</typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <param name="taskOptions">A set of task continuation options to apply</param>
-    /// <param name="scheduler">The task scheduler to schedule the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task ContinueWith<TInResult>(this Task<TInResult> task, Action<Task<TInResult>, object> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    /// <param name="continuationAction">
+    /// An action to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation action.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its
+    /// execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task"/> will not be scheduled for execution until the current task has
+    /// completed. If the criteria specified through the <paramref name="continuationOptions"/> parameter
+    /// are not met, the continuation task will be canceled instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationAction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task ContinueWith<TResult>(this Task<TResult> task, Action<Task<TResult>, object> continuationAction, object state, CancellationToken cancellationToken, TaskContinuationOptions continuationOptions, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithInState<TInResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+        return task.ContinueWith(new ContinueWithInState<TResult>(continuationAction, state).ContinueWith, cancellationToken, continuationOptions, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <returns>A new continuation <see cref="Task{TResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TResult}"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> continuationFunction, object state)
     {
-        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith);
+        return task.ContinueWith(new ContinueWithOutState<TResult>(continuationFunction, state).ContinueWith);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <returns>A new continuation <see cref="Task{TResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TResult}"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> continuationFunction, object state, CancellationToken cancellationToken)
     {
-        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, token);
+        return task.ContinueWith(new ContinueWithOutState<TResult>(continuationFunction, state).ContinueWith, cancellationToken);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, TaskContinuationOptions taskOptions)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TResult}"/> will not be scheduled for execution until the current task has
+    /// completed. If the continuation criteria specified through the <paramref
+    /// name="continuationOptions"/> parameter are not met, the continuation task will be canceled
+    /// instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> continuationFunction, object state, TaskContinuationOptions continuationOptions)
     {
-        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+        return task.ContinueWith(new ContinueWithOutState<TResult>(continuationFunction, state).ContinueWith, CancellationToken.None, continuationOptions, TaskScheduler.Current);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, TaskScheduler scheduler)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task"/> completes.  When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TResult}"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> continuationFunction, object state, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+        return task.ContinueWith(new ContinueWithOutState<TResult>(continuationFunction, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
-    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new continuation task.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its
+    /// execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TResult}"/> will not be scheduled for execution until the current task has
+    /// completed. If the criteria specified through the <paramref name="continuationOptions"/> parameter
+    /// are not met, the continuation task will be canceled instead of scheduled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task<TResult> ContinueWith<TResult>(this Task task, Func<Task, object, TResult> continuationFunction, object state, CancellationToken cancellationToken, TaskContinuationOptions continuationOptions, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithOutState<TResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+        return task.ContinueWith(new ContinueWithOutState<TResult>(continuationFunction, state).ContinueWith, cancellationToken, continuationOptions, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result produced by the target Task</typeparam>
+    /// <typeparam name="TNewResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <returns>A new continuation <see cref="Task{TNewResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TNewResult}"/> will not be scheduled for execution until the current
+    /// task has completed, whether it completes due to running to completion successfully, faulting due
+    /// to an unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    public static Task<TNewResult> ContinueWith<TResult, TNewResult>(this Task<TResult> task, Func<Task<TResult>, object, TNewResult> continuationFunction, object state)
     {
-        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith);
+        return task.ContinueWith(new ContinueWithInOutState<TResult, TNewResult>(continuationFunction, state).ContinueWith);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result produced by the target Task</typeparam>
+    /// <typeparam name="TNewResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new task.</param>
+    /// <returns>A new continuation <see cref="Task{TNewResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TNewResult}"/> will not be scheduled for execution until the current
+    /// task has completed, whether it completes due to running to completion successfully, faulting due
+    /// to an unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task<TNewResult> ContinueWith<TResult, TNewResult>(this Task<TResult> task, Func<Task<TResult>, object, TNewResult> continuationFunction, object state, CancellationToken cancellationToken)
     {
-        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, token);
+        return task.ContinueWith(new ContinueWithInOutState<TResult, TNewResult>(continuationFunction, state).ContinueWith, cancellationToken);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result produced by the target Task</typeparam>
+    /// <typeparam name="TNewResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, TaskContinuationOptions taskOptions)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TNewResult}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The returned <see cref="Task{TNewResult}"/> will not be scheduled for execution until the current
+    /// task has completed, whether it completes due to running to completion successfully, faulting due
+    /// to an unhandled exception, or exiting out early due to being canceled.
+    /// </para>
+    /// <para>
+    /// The <paramref name="continuationFunction"/>, when executed, should return a <see
+    /// cref="Task{TNewResult}"/>. This task's completion state will be transferred to the task returned
+    /// from the ContinueWith call.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    public static Task<TNewResult> ContinueWith<TResult, TNewResult>(this Task<TResult> task, Func<Task<TResult>, object, TNewResult> continuationFunction, object state, TaskContinuationOptions continuationOptions)
     {
-        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, CancellationToken.None, taskOptions, TaskScheduler.Current);
+        return task.ContinueWith(new ContinueWithInOutState<TResult, TNewResult>(continuationFunction, state).ContinueWith, CancellationToken.None, continuationOptions, TaskScheduler.Current);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result produced by the target Task</typeparam>
+    /// <typeparam name="TNewResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, TaskScheduler scheduler)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task{TResult}"/> completes.  When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TNewResult}"/>.</returns>
+    /// <remarks>
+    /// The returned <see cref="Task{TNewResult}"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    public static Task<TNewResult> ContinueWith<TResult, TNewResult>(this Task<TResult> task, Func<Task<TResult>, object, TNewResult> continuationFunction, object state, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
+        return task.ContinueWith(new ContinueWithInOutState<TResult, TNewResult>(continuationFunction, state).ContinueWith, CancellationToken.None, TaskContinuationOptions.None, scheduler);
     }
 
     /// <summary>
-    /// Creates a continuation that executes asynchronously when the target Task completes
+    /// Creates a continuation that executes when the target <see cref="Task{TResult}"/> completes.
     /// </summary>
+    /// <typeparam name="TResult">The type of the result produced by the target Task</typeparam>
+    /// <typeparam name="TNewResult">
+    /// The type of the result produced by the continuation.
+    /// </typeparam>
     /// <param name="task">The target Task</param>
-    /// <param name="action">The continuation method to execute</param>
-    /// <param name="state">A state object to pass to the continuation</param>
-    /// <param name="token">A cancellation token to abort the continuation</param>
-    /// <param name="taskOptions">Options for when the continuation is scheduled</param>
-    /// <param name="scheduler">The Task Scheduler to associate with the continuation Task</param>
-    /// <returns>A task representing the continuation status</returns>
-    public static Task<TResult> ContinueWith<TInResult, TResult>(this Task<TInResult> task, Func<Task<TInResult>, object, TResult> action, object state, CancellationToken token, TaskContinuationOptions taskOptions, TaskScheduler scheduler)
+    /// <param name="continuationFunction">
+    /// A function to run when the <see cref="Task{TResult}"/> completes. When run, the delegate will be
+    /// passed the completed task and the caller-supplied state object as arguments.
+    /// </param>
+    /// <param name="state">An object representing data to be used by the continuation function.</param>
+    /// <param name="cancellationToken">The <see cref="CancellationToken"/> that will be assigned to the new task.</param>
+    /// <param name="continuationOptions">
+    /// Options for when the continuation is scheduled and how it behaves. This includes criteria, such
+    /// as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.OnlyOnCanceled">OnlyOnCanceled</see>, as
+    /// well as execution options, such as <see
+    /// cref="System.Threading.Tasks.TaskContinuationOptions.ExecuteSynchronously">ExecuteSynchronously</see>.
+    /// </param>
+    /// <param name="scheduler">
+    /// The <see cref="TaskScheduler"/> to associate with the continuation task and to use for its
+    /// execution.
+    /// </param>
+    /// <returns>A new continuation <see cref="Task{TNewResult}"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// The returned <see cref="Task{TNewResult}"/> will not be scheduled for execution until the current task has
+    /// completed, whether it completes due to running to completion successfully, faulting due to an
+    /// unhandled exception, or exiting out early due to being canceled.
+    /// </para>
+    /// <para>
+    /// The <paramref name="continuationFunction"/>, when executed, should return a <see cref="Task{TNewResult}"/>.
+    /// This task's completion state will be transferred to the task returned from the
+    /// ContinueWith call.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="continuationFunction"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentOutOfRangeException">
+    /// The <paramref name="continuationOptions"/> argument specifies an invalid value for <see
+    /// cref="T:System.Threading.Tasks.TaskContinuationOptions">TaskContinuationOptions</see>.
+    /// </exception>
+    /// <exception cref="T:System.ArgumentNullException">
+    /// The <paramref name="scheduler"/> argument is null.
+    /// </exception>
+    /// <exception cref="T:System.ObjectDisposedException">The provided <see cref="System.Threading.CancellationToken">CancellationToken</see>
+    /// has already been disposed.
+    /// </exception>
+    public static Task<TNewResult> ContinueWith<TResult, TNewResult>(this Task<TResult> task, Func<Task<TResult>, object, TNewResult> continuationFunction, object state, CancellationToken cancellationToken, TaskContinuationOptions continuationOptions, TaskScheduler scheduler)
     {
-        return task.ContinueWith(new ContinueWithInOutState<TInResult, TResult>(action, state).ContinueWith, token, taskOptions, scheduler);
+        return task.ContinueWith(new ContinueWithInOutState<TResult, TNewResult>(continuationFunction, state).ContinueWith, cancellationToken, continuationOptions, scheduler);
     }
 
     private sealed class ContinueWithState
     {
-        private readonly Action<Task, object> _Callback;
-        private readonly object _State;
+        private readonly Action<Task, object> _continuationAction;
+        private readonly object _state;
 
-        internal ContinueWithState(Action<Task, object> callback, object state)
+        internal ContinueWithState(Action<Task, object> continuationAction, object state)
         {
-            _Callback = callback;
-            _State = state;
+            if (continuationAction == null)
+                throw new ArgumentNullException(nameof(continuationAction));
+
+            _continuationAction = continuationAction;
+            _state = state;
         }
 
         internal void ContinueWith(Task task)
         {
-            _Callback(task, _State);
+            _continuationAction(task, _state);
         }
     }
 
     private sealed class ContinueWithInState<TIn>
     {
-        private readonly Action<Task<TIn>, object> _Callback;
-        private readonly object _State;
+        private readonly Action<Task<TIn>, object> _continuationAction;
+        private readonly object _state;
 
-        internal ContinueWithInState(Action<Task<TIn>, object> callback, object state)
+        internal ContinueWithInState(Action<Task<TIn>, object> continuationAction, object state)
         {
-            _Callback = callback;
-            _State = state;
+            if (continuationAction == null)
+                throw new ArgumentNullException(nameof(continuationAction));
+
+            _continuationAction = continuationAction;
+            _state = state;
         }
 
         internal void ContinueWith(Task<TIn> task)
         {
-            _Callback(task, _State);
+            _continuationAction(task, _state);
         }
     }
 
     private sealed class ContinueWithOutState<TOut>
     {
-        private readonly Func<Task, object, TOut> _Callback;
-        private readonly object _State;
+        private readonly Func<Task, object, TOut> _continuationFunction;
+        private readonly object _state;
 
-        internal ContinueWithOutState(Func<Task, object, TOut> callback, object state)
+        internal ContinueWithOutState(Func<Task, object, TOut> continuationFunction, object state)
         {
-            _Callback = callback;
-            _State = state;
+            if (continuationFunction == null)
+                throw new ArgumentNullException(nameof(continuationFunction));
+
+            _continuationFunction = continuationFunction;
+            _state = state;
         }
 
         internal TOut ContinueWith(Task task)
         {
-            return _Callback(task, _State);
+            return _continuationFunction(task, _state);
         }
     }
 
     private sealed class ContinueWithInOutState<TIn, TOut>
     {
-        private readonly Func<Task<TIn>, object, TOut> _Callback;
-        private readonly object _State;
+        private readonly Func<Task<TIn>, object, TOut> _continuationFunction;
+        private readonly object _state;
 
-        internal ContinueWithInOutState(Func<Task<TIn>, object, TOut> callback, object state)
+        internal ContinueWithInOutState(Func<Task<TIn>, object, TOut> continuationFunction, object state)
         {
-            _Callback = callback;
-            _State = state;
+            if (continuationFunction == null)
+                throw new ArgumentNullException(nameof(continuationFunction));
+
+            _continuationFunction = continuationFunction;
+            _state = state;
         }
 
         internal TOut ContinueWith(Task<TIn> task)
         {
-            return _Callback(task, _State);
+            return _continuationFunction(task, _state);
         }
     }
 }

--- a/src/pubapi/AsyncBridge.net35-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net35-client.pubapi.cs
@@ -7,6 +7,26 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 
     public static System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter<TResult>(this System.Threading.Tasks.Task<TResult> task);

--- a/src/pubapi/AsyncBridge.net35-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net35-client.pubapi.cs
@@ -9,21 +9,41 @@ public static class AsyncCompatLibExtensions
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
-
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 

--- a/src/pubapi/AsyncBridge.net35-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net35-client.pubapi.cs
@@ -7,45 +7,45 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/src/pubapi/AsyncBridge.net40-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net40-client.pubapi.cs
@@ -7,6 +7,26 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 
     public static System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter<TResult>(this System.Threading.Tasks.Task<TResult> task);

--- a/src/pubapi/AsyncBridge.net40-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net40-client.pubapi.cs
@@ -9,21 +9,41 @@ public static class AsyncCompatLibExtensions
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
-
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 

--- a/src/pubapi/AsyncBridge.net40-client.pubapi.cs
+++ b/src/pubapi/AsyncBridge.net40-client.pubapi.cs
@@ -7,45 +7,45 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
+++ b/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
@@ -7,6 +7,26 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 
     public static System.Runtime.CompilerServices.TaskAwaiter<TResult> GetAwaiter<TResult>(this System.Threading.Tasks.Task<TResult> task);

--- a/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
+++ b/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
@@ -9,21 +9,41 @@ public static class AsyncCompatLibExtensions
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
-
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
 

--- a/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
+++ b/src/pubapi/AsyncBridge.portable-net40+sl5.pubapi.cs
@@ -7,45 +7,45 @@ public static class AsyncCompatLibExtensions
 
     public static System.Runtime.CompilerServices.ConfiguredTaskAwaitable ConfigureAwait(this System.Threading.Tasks.Task task, bool continueOnCapturedContext);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith(this System.Threading.Tasks.Task task, System.Action<System.Threading.Tasks.Task, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task ContinueWith<TInResult>(this System.Threading.Tasks.Task<TInResult> task, System.Action<System.Threading.Tasks.Task<TInResult>, object> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task ContinueWith<TResult>(this System.Threading.Tasks.Task<TResult> task, System.Action<System.Threading.Tasks.Task<TResult>, object> continuationAction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TResult> ContinueWith<TResult>(this System.Threading.Tasks.Task task, System.Func<System.Threading.Tasks.Task, object, TResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskContinuationOptions taskOptions);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskContinuationOptions continuationOptions);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.Tasks.TaskScheduler scheduler);
 
-    public static System.Threading.Tasks.Task<TResult> ContinueWith<TInResult, TResult>(this System.Threading.Tasks.Task<TInResult> task, System.Func<System.Threading.Tasks.Task<TInResult>, object, TResult> action, object state, System.Threading.CancellationToken token, System.Threading.Tasks.TaskContinuationOptions taskOptions, System.Threading.Tasks.TaskScheduler scheduler);
+    public static System.Threading.Tasks.Task<TNewResult> ContinueWith<TResult, TNewResult>(this System.Threading.Tasks.Task<TResult> task, System.Func<System.Threading.Tasks.Task<TResult>, object, TNewResult> continuationFunction, object state, System.Threading.CancellationToken cancellationToken, System.Threading.Tasks.TaskContinuationOptions continuationOptions, System.Threading.Tasks.TaskScheduler scheduler);
 
     public static System.Runtime.CompilerServices.TaskAwaiter GetAwaiter(this System.Threading.Tasks.Task task);
 

--- a/tests/AsyncBridge.Tests/ContinueWithTests.cs
+++ b/tests/AsyncBridge.Tests/ContinueWithTests.cs
@@ -1,0 +1,314 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+#if NET45
+using TaskEx = System.Threading.Tasks.Task;
+#endif
+
+#if NET45
+namespace ReferenceAsync.Tests
+#elif NET35
+namespace AsyncBridge.Net35.Tests
+#elif ATP
+namespace AsyncTargetingPack.Tests
+#else
+namespace AsyncBridge.Tests
+#endif
+{
+#if !ATP
+    [TestClass]
+    public class ContinueWithTests
+    {
+        [TestMethod]
+        public void Action()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Action<Task, object>)null, false);
+        }
+
+        [TestMethod]
+        public void ActionToken()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionTokenNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Action<Task, object>)null, false, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void ActionOptions()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, TaskContinuationOptions.None));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionOptionsNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Action<Task, object>)null, false, TaskContinuationOptions.None);
+        }
+
+        [TestMethod]
+        public void ActionScheduler()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionSchedulerNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Action<Task, object>)null, false, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void ActionTokenOptionsScheduler()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionTokenOptionsSchedulerNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Action<Task, object>)null, false, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void ActionResult()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionResultNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Action<Task<bool>, object>)null, false);
+        }
+
+        [TestMethod]
+        public void ActionResultToken()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionResultTokenNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Action<Task<bool>, object>)null, false, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void ActionResultOptions()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, TaskContinuationOptions.None));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionResultOptionsNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Action<Task<bool>, object>)null, false, TaskContinuationOptions.None);
+        }
+
+        [TestMethod]
+        public void ActionResultScheduler()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionResultSchedulerNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Action<Task<bool>, object>)null, false, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void ActionResultTokenOptionsScheduler()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void ActionResultTokenOptionsSchedulerNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Action<Task<bool>, object>)null, false, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void Func()
+        {
+            var GotState = false;
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { return GotState = (bool)state; }, true));
+            Assert.IsTrue(GotState);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Func<Task, object, bool>)null, false);
+        }
+
+        [TestMethod]
+        public void FuncToken()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { return GotState = (bool)state; }, true, CancellationToken.None));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncTokenNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Func<Task, object, bool>)null, false, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void FuncOptions()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { return GotState = (bool)state; }, true, TaskContinuationOptions.None));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncOptionsNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Func<Task, object, bool>)null, false, TaskContinuationOptions.None);
+        }
+
+        [TestMethod]
+        public void FuncScheduler()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { return GotState = (bool)state; }, true, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncSchedulerNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Func<Task, object, bool>)null, false, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void FuncTokenOptionsScheduler()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { return GotState = (bool)state; }, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncTokenOptionsSchedulerNull()
+        {
+            TaskEx.Run(() => { }).ContinueWith((Func<Task, object, bool>)null, false, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void FuncResult()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { return GotState = (bool)state; }, true));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncResultNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Func<Task<bool>, object, bool>)null, false);
+        }
+
+        [TestMethod]
+        public void FuncResultToken()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { return GotState = (bool)state; }, true, CancellationToken.None));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncResultTokenNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Func<Task<bool>, object, bool>)null, false, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public void FuncResultOptions()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { return GotState = (bool)state; }, true, TaskContinuationOptions.None));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncResultOptionsNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Func<Task<bool>, object, bool>)null, false, TaskContinuationOptions.None);
+        }
+
+        [TestMethod]
+        public void FuncResultScheduler()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { return GotState = (bool)state; }, true, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncResultSchedulerNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Func<Task<bool>, object, bool>)null, false, TaskScheduler.Current);
+        }
+
+        [TestMethod]
+        public void FuncResultTokenOptionsScheduler()
+        {
+            var GotState = false;
+            var GotResult = TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { return GotState = (bool)state; }, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            Assert.IsTrue(GotState);
+            Assert.IsTrue(GotResult);
+        }
+
+        [TestMethod, ExpectedException(typeof(ArgumentNullException))]
+        public void FuncResultTokenOptionsSchedulerNull()
+        {
+            TaskEx.Run(() => true).ContinueWith((Func<Task<bool>, object, bool>)null, false, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current);
+        }
+    }
+#endif
+}

--- a/tests/AsyncBridge.Tests/ContinueWithTests.cs
+++ b/tests/AsyncBridge.Tests/ContinueWithTests.cs
@@ -25,7 +25,7 @@ namespace AsyncBridge.Tests
         public void Action()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true));
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { GotState = (bool)state; }, true));
             Assert.IsTrue(GotState);
         }
 
@@ -39,7 +39,7 @@ namespace AsyncBridge.Tests
         public void ActionToken()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None));
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { GotState = (bool)state; }, true, CancellationToken.None));
             Assert.IsTrue(GotState);
         }
 
@@ -53,7 +53,7 @@ namespace AsyncBridge.Tests
         public void ActionOptions()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, TaskContinuationOptions.None));
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { GotState = (bool)state; }, true, TaskContinuationOptions.None));
             Assert.IsTrue(GotState);
         }
 
@@ -67,7 +67,7 @@ namespace AsyncBridge.Tests
         public void ActionScheduler()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, TaskScheduler.Current));
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { GotState = (bool)state; }, true, TaskScheduler.Current));
             Assert.IsTrue(GotState);
         }
 
@@ -81,7 +81,7 @@ namespace AsyncBridge.Tests
         public void ActionTokenOptionsScheduler()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            TestUtils.RunAsync(() => TaskEx.Run(() => { }).ContinueWith((task, state) => { GotState = (bool)state; }, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
             Assert.IsTrue(GotState);
         }
 
@@ -95,7 +95,7 @@ namespace AsyncBridge.Tests
         public void ActionResult()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true));
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { GotState = (bool)state; }, true));
             Assert.IsTrue(GotState);
         }
 
@@ -109,7 +109,7 @@ namespace AsyncBridge.Tests
         public void ActionResultToken()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None));
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { GotState = (bool)state; }, true, CancellationToken.None));
             Assert.IsTrue(GotState);
         }
 
@@ -123,7 +123,7 @@ namespace AsyncBridge.Tests
         public void ActionResultOptions()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, TaskContinuationOptions.None));
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { GotState = (bool)state; }, true, TaskContinuationOptions.None));
             Assert.IsTrue(GotState);
         }
 
@@ -137,7 +137,7 @@ namespace AsyncBridge.Tests
         public void ActionResultScheduler()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, TaskScheduler.Current));
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { GotState = (bool)state; }, true, TaskScheduler.Current));
             Assert.IsTrue(GotState);
         }
 
@@ -151,7 +151,7 @@ namespace AsyncBridge.Tests
         public void ActionResultTokenOptionsScheduler()
         {
             var GotState = false;
-            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => GotState = (bool)state, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
+            TestUtils.RunAsync(() => TaskEx.Run(() => true).ContinueWith((task, state) => { GotState = (bool)state; }, true, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Current));
             Assert.IsTrue(GotState);
         }
 

--- a/tests/AsyncBridge.Tests/TestUtils.cs
+++ b/tests/AsyncBridge.Tests/TestUtils.cs
@@ -18,5 +18,11 @@ namespace AsyncBridge.Tests
             if (asyncTestMethod == null) throw new ArgumentNullException(nameof(asyncTestMethod));
             asyncTestMethod.Invoke().GetAwaiter().GetResult();
         }
+
+        public static TResult RunAsync<TResult>(Func<Task<TResult>> asyncTestMethod)
+        {
+            if (asyncTestMethod == null) throw new ArgumentNullException(nameof(asyncTestMethod));
+            return asyncTestMethod.Invoke().GetAwaiter().GetResult();
+        }
     }
 }


### PR DESCRIPTION
Add ContinueWith overloads with the state parameter.

Found a few more that I'd missed in the previous PR, so I've added those.
Also, I've switched to handling the state value manually, because the compiler was creating 20 separate copies of exactly the same underlying class.